### PR TITLE
Wording around os-specific configuration "directory"

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -10,7 +10,7 @@ The default `config` directory order is as follows:
 - default location
 - system location (`/etc/zellij`)
 
-The default configuration location of your os:
+The default `config` directory of your os:
 
 **Linux**: `/home/alice/.config/zellij`
 

--- a/static/documentation/configuration.html
+++ b/static/documentation/configuration.html
@@ -173,7 +173,7 @@
 <li>default location</li>
 <li>system location (<code>/etc/zellij</code>)</li>
 </ul>
-<p>The default configuration location of your os:</p>
+<p>The default <code>config</code> directory of your os:</p>
 <p><strong>Linux</strong>: <code>/home/alice/.config/zellij</code></p>
 <p><strong>Mac</strong>: <code>/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij</code></p>
 <p>In order to  pass a config file directly to zellij:</p>

--- a/static/documentation/print.html
+++ b/static/documentation/print.html
@@ -210,7 +210,7 @@ https://github.com/zellij-org/zellij/releases</p>
 <li>default location</li>
 <li>system location (<code>/etc/zellij</code>)</li>
 </ul>
-<p>The default configuration location of your os:</p>
+<p>The default <code>config</code> directory of your os:</p>
 <p><strong>Linux</strong>: <code>/home/alice/.config/zellij</code></p>
 <p><strong>Mac</strong>: <code>/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij</code></p>
 <p>In order to  pass a config file directly to zellij:</p>


### PR DESCRIPTION
When trying to pick-up zellij I definitely had to re-read the configuration area to make sure I got my file location just right and then I saw https://github.com/zellij-org/zellij/issues/545 and realized that this was also confusing to me.

Instead of a sort-of vague "config location" make sure to specify it is a config _directory_