### PR TITLE
Rework OS-specific configuration directories

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -8,13 +8,10 @@ The default `config` directory order is as follows:
 - `ZELLIJ_CONFIG_DIR` env variable
 - `$HOME/.config/zellij`
 - default location
+    - Linux: `/home/alice/.config/zellij`
+    - Mac: `/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij`
+
 - system location (`/etc/zellij`)
-
-The default `config` directory of your os:
-
-**Linux**: `/home/alice/.config/zellij`
-
-**Mac**: `/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij`
 
 In order to  pass a config file directly to zellij:
 

--- a/static/documentation/configuration.html
+++ b/static/documentation/configuration.html
@@ -170,12 +170,14 @@
 <li><code>--config-dir</code> flag</li>
 <li><code>ZELLIJ_CONFIG_DIR</code> env variable</li>
 <li><code>$HOME/.config/zellij</code></li>
-<li>default location</li>
+<li>default location
+<ul>
+<li>Linux: <code>/home/alice/.config/zellij</code></li>
+<li>Mac: <code>/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij</code></li>
+</ul>
+</li>
 <li>system location (<code>/etc/zellij</code>)</li>
 </ul>
-<p>The default <code>config</code> directory of your os:</p>
-<p><strong>Linux</strong>: <code>/home/alice/.config/zellij</code></p>
-<p><strong>Mac</strong>: <code>/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij</code></p>
 <p>In order to  pass a config file directly to zellij:</p>
 <pre><code>zellij --config [FILE]
 </code></pre>

--- a/static/documentation/print.html
+++ b/static/documentation/print.html
@@ -207,12 +207,14 @@ https://github.com/zellij-org/zellij/releases</p>
 <li><code>--config-dir</code> flag</li>
 <li><code>ZELLIJ_CONFIG_DIR</code> env variable</li>
 <li><code>$HOME/.config/zellij</code></li>
-<li>default location</li>
+<li>default location
+<ul>
+<li>Linux: <code>/home/alice/.config/zellij</code></li>
+<li>Mac: <code>/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij</code></li>
+</ul>
+</li>
 <li>system location (<code>/etc/zellij</code>)</li>
 </ul>
-<p>The default <code>config</code> directory of your os:</p>
-<p><strong>Linux</strong>: <code>/home/alice/.config/zellij</code></p>
-<p><strong>Mac</strong>: <code>/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij</code></p>
 <p>In order to  pass a config file directly to zellij:</p>
 <pre><code>zellij --config [FILE]
 </code></pre>


### PR DESCRIPTION
Follow-on to https://github.com/zellij-org/zellij-org.github.io/pull/28 discussion

Trying to get the OS-specific directories to be clear for where to put configuration fiels