### PR TITLE
Remove deprecated google_news template

### DIFF
--- a/themes/hello-friend-ng/layouts/partials/head.html
+++ b/themes/hello-friend-ng/layouts/partials/head.html
@@ -37,7 +37,6 @@
 
 {{ template "_internal/schema.html" . }}
 {{ template "_internal/twitter_cards.html" . }}
-{{ template "_internal/google_news.html" . }}
 
 {{ if isset .Site.Taxonomies "series" }}
     {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
This template causes the following warning:
```
WARN 2022/02/21 01:17:44 The google_news internal template will be removed in a future release. Please remove calls to this template. See https://github.com/gohugoio/hugo/issues/9172 for additional information.
```

Ref: https://github.com/gohugoio/hugo/issues/9172