### PR TITLE
Add `.hugo_build.lock` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .envrc
 .direnv/
+.hugo_build.lock


### PR DESCRIPTION
It seems that `.hugo_build.lock` does not need to be included in this project, so I added it to the gitignore target.