### PR TITLE
Replace deprecated `.URL` with `.RelPermalink`

### DIFF
--- a/themes/hello-friend-ng/layouts/partials/logo.html
+++ b/themes/hello-friend-ng/layouts/partials/logo.html
@@ -6,7 +6,7 @@
         <!-- <span class="logo__mark">{{ with .Site.Params.Logo.logoMark }}{{ . }}{{ else }}>{{ end }}</span> -->
             <span class="logo__mark"><img src="/img/logo.png" alt="Zellij logo"></span>
             <!-- <span class="logo__text">{{ with .Site.Params.Logo.logoText }}{{ . }}{{ else }}hello{{ end }}</span> -->
-            <span class="logo__text">~/zellij{{ .URL }}</span>
+            <span class="logo__text">~/zellij{{ .RelPermalink }}</span>
             <span class="logo__cursor" style=
                   "{{ with.Site.Params.Logo.logoCursorDisabled }}visibility:hidden;{{ end }}
                    {{ with.Site.Params.Logo.logoCursorColor    }}background-color:{{ . }};{{ end }}


### PR DESCRIPTION
This PR removes deprecated `.URL` and introduces `.RelPermalink`.
Before applying this change, the following error had been caused.

```
ERROR 2022/02/21 01:22:05 Page.URL is deprecated and will be removed in Hugo 0.93.0. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url
```

FYI: https://discourse.gohugo.io/t/pages-url-is-deprecated/20645