### PR TITLE
Containerize dependencies

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,8 @@
+FROM docker.io/peaceiris/mdbook:v0.4.15
+
+RUN apk update && apk add hugo
+
+# We must give it a bind address, otherwise it will listen to connections from
+# 127.0.0.1. Since we connect to the server from "outside" the container, this
+# doesn't work.
+ENTRYPOINT mdbook watch docs/ -d ../static/documentation & hugo server --bind 0.0.0.0;

--- a/watch-serve.sh
+++ b/watch-serve.sh
@@ -19,14 +19,14 @@ if $(_exists podman); then
     echo "Using '$CRT' as container runtime"
 
     $CRT build --tag "$CONTAINER_NAME" -f Containerfile
-    $CRT run --userns keep-id --user "$(id -u):$(id -g)" -v "$PWD:$PWD:z" -w "$PWD" -p 1313:1313 $CONTAINER_NAME
+    $CRT run --rm -it --userns keep-id --user "$(id -u):$(id -g)" -v "$PWD:$PWD:z" -w "$PWD" -p 1313:1313 $CONTAINER_NAME
 
 elif $(_exists docker); then
     CRT="$(which docker)"
     echo "Using '$CRT' as container runtime"
 
     $CRT build --tag "$CONTAINER_NAME" <Containerfile
-    $CRT run --user "$(id -u):$(id -g)" -v "$PWD:$PWD" -w "$PWD" -p 1313:1313 $CONTAINER_NAME
+    $CRT run --rm -it --user "$(id -u):$(id -g)" -v "$PWD:$PWD" -w "$PWD" -p 1313:1313 $CONTAINER_NAME
 
 else
     echo "You must have installed either of:"

--- a/watch-serve.sh
+++ b/watch-serve.sh
@@ -5,7 +5,7 @@ function _exists {
     command -v "$1" >/dev/null
 }
 
-if [[ $(_exists mdbook) && $(_exists hugo) ]]; then
+if $(_exists mdbook) && $(_exists hugo); then
     { mdbook watch docs/ -d ../static/documentation & hugo server; }
     exit 0
 fi
@@ -14,7 +14,12 @@ fi
 CRT=""
 CONTAINER_NAME="zellij-docs:latest"
 
-if $(_exists podman); then
+if $(_exists nix-shell); then
+    echo "Using nix to execute script"
+
+    nix-shell --command "$0"
+
+elif $(_exists podman); then
     CRT="$(which podman)"
     echo "Using '$CRT' as container runtime"
 
@@ -31,6 +36,7 @@ elif $(_exists docker); then
 else
     echo "You must have installed either of:"
     echo ""
+    echo "  - nix"
     echo "  - docker"
     echo "  - podman"
     echo "  - mdbook AND hugo"

--- a/watch-serve.sh
+++ b/watch-serve.sh
@@ -1,3 +1,42 @@
 #!/usr/bin/env bash
 
-{ mdbook watch docs/ -d ../static/documentation & hugo server; }
+# Return 0 if command $1 exists, 1 otherwise.
+function _exists {
+    command -v "$1" >/dev/null
+}
+
+if [[ $(_exists mdbook) && $(_exists hugo) ]]; then
+    { mdbook watch docs/ -d ../static/documentation & hugo server; }
+    exit 0
+fi
+
+# Some pre-requisites are missing, try to use containers
+CRT=""
+CONTAINER_NAME="zellij-docs:latest"
+
+if $(_exists podman); then
+    CRT="$(which podman)"
+    echo "Using '$CRT' as container runtime"
+
+    $CRT build --tag "$CONTAINER_NAME" -f Containerfile
+    $CRT run --userns keep-id --user "$(id -u):$(id -g)" -v "$PWD:$PWD:z" -w "$PWD" -p 1313:1313 $CONTAINER_NAME
+
+elif $(_exists docker); then
+    CRT="$(which docker)"
+    echo "Using '$CRT' as container runtime"
+
+    $CRT build --tag "$CONTAINER_NAME" <Containerfile
+    $CRT run --user "$(id -u):$(id -g)" -v "$PWD:$PWD" -w "$PWD" -p 1313:1313 $CONTAINER_NAME
+
+else
+    echo "You must have installed either of:"
+    echo ""
+    echo "  - docker"
+    echo "  - podman"
+    echo "  - mdbook AND hugo"
+    echo ""
+    echo "To compile and preview the docs locally."
+    exit 1
+fi
+
+exit 0

--- a/watch-serve.sh
+++ b/watch-serve.sh
@@ -14,10 +14,16 @@ fi
 CRT=""
 CONTAINER_NAME="zellij-docs:latest"
 
-if $(_exists nix-shell); then
-    echo "Using nix to execute script"
+if $(_exists nix); then
+    echo "Trying 'nix develop' to execute script"
 
-    nix-shell --command "$0"
+    nix develop --command "$0"
+
+    if [[ $? -ne 0 ]] && $(_exists nix-shell); then
+        echo "Using 'nix-shell' to execute script instead"
+
+        nix-shell --command "$0"
+    fi
 
 elif $(_exists podman); then
     CRT="$(which podman)"


### PR DESCRIPTION
This MR introduces a `Containerfile` that builds a container with all the doc dependencies (`mdbook` and `hugo`), and expands the `watch-serve.sh` to make use of this container if the deps aren't available locally.

It should work with both podman and docker as container runtimes, although I only have podman so I couldn't yet verify whether it really works with docker. *If someone reading this has docker, I'd be thankful for feedback on that*.

If neither the deps nor a container runtime can be found, a message is now printed to stdout to inform the user what's missing.