### PR TITLE
Fix typo

### DIFF
--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -41,11 +41,11 @@ Functionality to help with the setup of zellij.
 
 | Flag                                |  Description|
 |:------------------------------------|------------------|
-| --check                             |  Checks the configuration |
+| --check                             |  Check the configuration |
 | --clean                             |  Start with default configuration|
 | --dump-config                       |  Dump the default configuration file to stdout|
 | --dump-layout [LAYOUT]      |  Dump a specified default layout file to stdout |
-| --generate-completions [SHELL]      |  Generate completions for the specified shell|
+| --generate-completion [SHELL]      |  Generate completions for the specified shell|
 
 # Flags
 These flags can be invoked with `zellij --flag`.


### PR DESCRIPTION
This PR fixes a minor typo in `commands.md`. Also replaces "checks" with "check" which is not really a typo, but I thought it's more consistent with the other rows.