### PR TITLE
Remove deprecated google_news template

### DIFF
--- a/themes/hello-friend-ng/layouts/partials/head.html
+++ b/themes/hello-friend-ng/layouts/partials/head.html
@@ -37,7 +37,6 @@
 
 {{ template "_internal/schema.html" . }}
 {{ template "_internal/twitter_cards.html" . }}
-{{ template "_internal/google_news.html" . }}
 
 {{ if isset .Site.Taxonomies "series" }}
     {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
This PR restores https://github.com/zellij-org/zellij-org.github.io/pull/88.