### PR TITLE
Add `.hugo_build.lock` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .envrc
 .direnv/
+.hugo_build.lock


### PR DESCRIPTION
This PR restores https://github.com/zellij-org/zellij-org.github.io/pull/89.