### PR TITLE
Add an 's' to 'layout' so the correct 'layouts' path is quoted in the…

### DIFF
--- a/docs/src/layouts.md
+++ b/docs/src/layouts.md
@@ -8,7 +8,7 @@ zellij --layout-path /path/to/your/layout_file.yaml
 ```
 
 By default Zellij will load the `default.yaml` layout, that is found in the
-`layout` directory (by default a subdirectory of the `config`
+`layouts` directory (by default a subdirectory of the `config`
 directory [config/layouts]). Falling back to an internal default layout,
 if not found.
 Layouts residing in the default directory can be accessed as follows:


### PR DESCRIPTION
Fix trivial typo that caused me to stumble - adds an `s` to `layout` so the correct`'layouts` path is quoted in the documentation