### PR TITLE
add zellij-compact-status to plugin overview

### DIFF
--- a/docs/src/plugin-overview.md
+++ b/docs/src/plugin-overview.md
@@ -10,6 +10,7 @@ not necessarily connected to zellij maintainers:
 
 * [zellij-pomodoro-plugin][zellij-pomodoro-plugin]
 * [z-tab-bar][z-tab-bar]: a tmux-like tab-bar.
+* [zellij-compact-status][zellij-compact-status]: a compact status bar.
 
 
 
@@ -17,6 +18,7 @@ not necessarily connected to zellij maintainers:
 
 [zellij-pomodoro-plugin]: https://github.com/tw4452852/zellij-pomodoro-plugin
 [z-tab-bar]: https://github.com/casonadams/z-tab-bar
+[zellij-compact-status]: https://mzte.de/git/LordMZTE/zellij-compact-status
 [tab-bar]: https://github.com/zellij-org/zellij/tree/main/default-plugins/tab-bar
 [strider]: https://github.com/zellij-org/zellij/tree/main/default-plugins/strider
 [status-bar]: https://github.com/zellij-org/zellij/tree/main/default-plugins/status-bar


### PR DESCRIPTION
This adds my plugint to the plugin overview, which is a compact version of the status bar.