### PR TITLE
feat: make mention of using a command to open a pane in a certain diectory

### DIFF
--- a/docs/src/layouts.md
+++ b/docs/src/layouts.md
@@ -118,7 +118,7 @@ run:
   command: {cmd: htop, args: ["-C"]}
 ```
 
-This can be used to open a pane in a specified directory by making use of your shell's `command` flag and `cd path/to/direcotyr && <shell>`.
+This can be used to open a pane in a specified directory by making use of your shell's `command` flag and `cd path/to/directory && <shell>`. The following command is **only** for `zsh`. It may work for other shells, but it is not guaranteed. Check your shell's documentation for how to use the command flag.
 
 Example:
 ```

--- a/docs/src/layouts.md
+++ b/docs/src/layouts.md
@@ -118,6 +118,14 @@ run:
   command: {cmd: htop, args: ["-C"]}
 ```
 
+This can be used to open a pane in a specified directory by making use of your shell's `command` flag and `cd path/to/direcotyr && <shell>`.
+
+Example:
+```
+run:
+  command: { cmd: zsh, args: ["-c", "cd ~/Documents/code/zellij && zsh"] }
+```
+
 ### `name: <name-of-the-tab>`
 This is an optional command that can be used to name the `tab` in the tab layout
 section. 


### PR DESCRIPTION
I spent some time today making a custom layout and had to find a nice way to open a pane in a certain directory. In `tmux` I was able to just send a command to the pane and let it execute, but I didn't find anything similar for zellij. I did find, however, [thanks to this discussion](https://github.com/zellij-org/zellij/discussions/1049) that you can use the `command` flag for your shell, move to the directory and open the shell and it'll be where you want it, so I thought I'd open a PR so others can easily find the solution.

Let me know if any wording needs to be updated