### PR TITLE
fix(launch): portable shebang

### DIFF
--- a/static/launch
+++ b/static/launch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 dir="/tmp/zellij/bootstrap"
 mkdir -p "$dir"


### PR DESCRIPTION
The previous shebang was using a hardcoded location,
as opposed to a location that is universally more supported.

Now the more widely supported version is chosen.