### PR TITLE
Handle error when tar fails

### DIFF
--- a/static/launch
+++ b/static/launch
@@ -37,5 +37,13 @@ esac
 
 url="https://github.com/zellij-org/zellij/releases/latest/download/zellij-$arch-$sys.tar.gz"
 curl --location "$url" | tar -C "$dir" -xz
+if [[ $? -ne 0 ]]
+then
+    echo
+    echo "Extracting binary failed, cannot launch zellij :("
+    echo "One probable cause is that a new release just happened and the binary is currently building."
+    echo "Maybe try again later? :)"
+    exit 1
+fi
 "$dir/zellij" "$@"
 exit


### PR DESCRIPTION
discovered in https://github.com/zellij-org/zellij/issues/1632

