### PR TITLE
Use the new GitHub Actions Workflow for Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,22 +1,65 @@
-name: Push to GitHub Pages on push to master
+name: Push to GitHub Pages on push to main
 on:
+  # Runs on pushes targeting the default branch
   push:
     branches:
       - main
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
 jobs:
+  # Build job
   build:
-    name: Deploy
     runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.99.0
     steps:
-      - name: Checkout master
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Deploy the site
-        uses: benmatselby/hugo-deploy-gh-pages@master
-        env:
-          HUGO_VERSION: 0.82.0
-          HUGO_EXTENDED: true
-          TARGET_REPO: zellij-org/zellij.dev
-          TARGET_BRANCH: gh-pages
-          TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v1
+
+      - name: Build with Hugo
+        run: |
+          hugo \
+            --minify \
+            --baseURL ${{ steps.pages.outputs.base_url }}
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./public
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
I used a recently released beta feature, so if you would avoid using a beta, please let me know.

https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/

IMHO, the advantages of the feature are no `gh-pages` branch and no secret tokens are needed.
Especially since secret tokens are always at risk of exposure, it would be preferable not to have them.

The patch includes most of this template: https://github.com/actions/starter-workflows/blob/main/pages/hugo.yml.
`HUGO_VERSION` is also bumped up from `0.82.0` to `0.99.0`.

---

Tasks for a repository owner once this PR is merged:

1. Go to https://github.com/zellij-org/zellij-org.github.io/settings/pages
2. Change `Source` to `GitHub Actions`
3. (optional) Delete the `gh-pages` branch
4. (optional) Delete the `DEPLOY_TOKEN` secret
5. (optional) If the `DEPLOY_TOKEN` is a personal access token, go to https://github.com/settings/tokens and delete it