### PR TITLE
Simplify the snippet for listing and attaching to current sessions

### DIFF
--- a/docs/src/integration.md
+++ b/docs/src/integration.md
@@ -66,15 +66,7 @@ Depends on [`sk`](https://github.com/lotabout/skim) & `bash`
 
 ```
 #!/usr/bin/env bash
-ZJ_SESSIONS=$(zellij list-sessions)
-NO_SESSIONS=$(echo "${ZJ_SESSIONS}" | wc -l)
-
-if [ "${NO_SESSIONS}" -ge 2 ]; then
-    zellij attach \
-    "$(echo "${ZJ_SESSIONS}" | sk)"
-else
-   zellij attach -c
-fi
+zellij attach $(zellij list-sessions | sk -0 -1) -c
 ```
 
 ## List layout files and create a layout


### PR DESCRIPTION
Simplify the snippet for listing and attaching to current sessions to a one-liner that still handles all cases by using `sk -0 -1`, which automatically exists in case there are no sessions, and in case there is only one session, it automatically selects it.