### PR TITLE
Fix `kill-sessions` typo in commands page

### DIFF
--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -18,7 +18,7 @@ short: `ls`
 
 Will list all the names of currently running sessions.
 
-## `kill-sessions [target-session]`
+## `kill-session [target-session]`
 short: `k`
 
 Will kill the session with the name of `[target-session]`, if it is currently


### PR DESCRIPTION
There is a difference between the docs website and the command in Zellij itself.  Updated the commands docs page to match the cli.
![image](https://github.com/zellij-org/zellij-org.github.io/assets/9434150/beec5b34-234d-4a2f-9aa7-e5f66127b800)
