### PR TITLE
add kitty mac opt as alt faq

### DIFF
--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -26,6 +26,7 @@ This depends on which terminal emulator you're using. Here are some links that m
 1. [iTerm2](https://www.clairecodes.com/blog/2018-10-15-making-the-alt-key-work-in-iterm2/)
 2. [Terminal.app](https://superuser.com/questions/1038947/using-the-option-key-properly-on-mac-terminal)
 3. [Alacritty](https://github.com/zellij-org/zellij/issues/2051#issuecomment-1461519892)
+4. [Kitty](https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.macos_option_as_alt)
 
 ## Copy / Paste isn't working, how can I fix this?
 Some terminals don't support the the OSC 52 signal, which is the method Zellij uses by default to copy text to the clipboard. To get around this, you can either switch to a supported terminal (eg. Alacritty or xterm) or configure Zellij to use an external utility when copy pasting (eg. xclip, wl-copy or pbcopy).

--- a/static/documentation/faq.html
+++ b/static/documentation/faq.html
@@ -163,6 +163,7 @@
 <li><a href="https://www.clairecodes.com/blog/2018-10-15-making-the-alt-key-work-in-iterm2/">iTerm2</a></li>
 <li><a href="https://superuser.com/questions/1038947/using-the-option-key-properly-on-mac-terminal">Terminal.app</a></li>
 <li><a href="https://github.com/zellij-org/zellij/issues/2051#issuecomment-1461519892">Alacritty</a></li>
+<li><a href="https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.macos_option_as_alt">Kitty</a></li>
 </ol>
 <h2 id="copy--paste-isnt-working-how-can-i-fix-this"><a class="header" href="#copy--paste-isnt-working-how-can-i-fix-this">Copy / Paste isn't working, how can I fix this?</a></h2>
 <p>Some terminals don't support the the OSC 52 signal, which is the method Zellij uses by default to copy text to the clipboard. To get around this, you can either switch to a supported terminal (eg. Alacritty or xterm) or configure Zellij to use an external utility when copy pasting (eg. xclip, wl-copy or pbcopy).</p>


### PR DESCRIPTION
Kitty is Similar to Alacritty in it's use of Option on Mac. Adding a similar link to the FAQ for Kitty users that may face this issue