### PR TITLE
Make it clear what the config directory is

### DIFF
--- a/docs/src/layouts.md
+++ b/docs/src/layouts.md
@@ -43,7 +43,7 @@ For more info, see: [Controlling Zellij through the CLI](./controlling-zellij-th
 
 ### Layout default directory
 
-By default Zellij will load the `default.kdl` layout, found in the `layouts` directory (a subdirectory of the `config` directory [config/layouts]).
+By default Zellij will load the `default.kdl` layout, found in the `layouts` directory (a subdirectory of the (`config` directory)[./configuration.md]).
 
 If not found, Zellij will start with one pane and one tab.
 


### PR DESCRIPTION
The wording here was not 100% clear (to me at least), where the actual layout directory is.
By linking to the configuration documentation, which clearly states that the configuration directory is `.config/zellij`, and the sentence that the layout directory is a subdirectory to that, this clearifies the location for me.

---

Closes #205 