### PR TITLE
docs(configuration): improved info on config files and directories

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -12,18 +12,25 @@ zellij setup --dump-config > ~/.config/zellij/config.kdl
 
 ## Where does Zellij look for the config file?
 
-By default Zellij will look for `config.kdl` in the `config` directory.
+By default, Zellij will look for `config.kdl` in its config directory.
 
-Zellij will search for the `config` directory as follows:
+Zellij will search for the config director in the following order:
 
-- `--config-dir` flag
-- `ZELLIJ_CONFIG_DIR` env variable
+- As specified by the `--config-dir` flag
+- At the path provided by the `ZELLIJ_CONFIG_DIR` environment variable
+- At the default location:
+    - Linux: `$HOME/.config/<zellij-project-dir>` (e.g. `/home/alice/.config/zellij`)
+    - Mac:  `$HOME/Library/Application Support/<zellij-project-dir>` (e.g. `/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij`)\
+      (`<zellij-project-dir>` is specific to the Rust package, and cannot be changed by the user)
+- `$XDG_CONFIG_HOME/zellij`
 - `$HOME/.config/zellij`
-- default location
-    - Linux: `/home/alice/.config/zellij`
-    - Mac: `/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij`
+- At the system default location (always set to `/etc/zellij` - platform-specific locations)
 
-- system location (`/etc/zellij`)
+Zellij determines the name of the configuration file in the following order:
+
+- As specified by the `--config` flag
+- `ZELLIJ_CONFIG_FILE` environment variable
+- `config.kdl` if none of the above are set
 
 ## How to bypass the config file?
 


### PR DESCRIPTION
Modified the docs configuration page to be more complete and accurate.

This PR is okay by itself, but note that I made these changes along with some changes to the manpage in [Zellij PR #2957](https://github.com/zellij-org/zellij/pull/2957)