### PR TITLE
Add `copy_command` example for WSL

### DIFF
--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -120,6 +120,7 @@ Examples:
 copy_command "xclip -selection clipboard" // x11
 copy_command "wl-copy"                    // wayland
 copy_command "pbcopy"                     // osx
+copy_command "clip.exe"                   // Windows WSL2
 ```
 
 ### copy_clipboard


### PR DESCRIPTION
This PR just adds another example to the [copy_command section](https://zellij.dev/documentation/options#copy_command) of the documentation. I had to dig around to find out how to make copy work in WSL2 with zellij. This might save others some time.

Thanks for the cool project and the hard work! :heart: 

