### PR TITLE
fix: update `zellij pipe` example command

### DIFF
--- a/docs/src/zellij-pipe.md
+++ b/docs/src/zellij-pipe.md
@@ -4,7 +4,7 @@ Zellij [pipes](./plugin-pipes.md) provide a way to send messages to one or more 
 
 eg.
 ```
-$ zellij plugin -- https://path/to/my/plugin.wasm
+$ zellij pipe -- my_arbitrary_data
 ```
 
 **USAGE**:


### PR DESCRIPTION
The example of the `pipe` command is currently the example from the `plugin` command. 