### PR TITLE
Fix a script for `List current sessions`

### DIFF
--- a/docs/src/integration.md
+++ b/docs/src/integration.md
@@ -67,7 +67,7 @@ Depends on [`sk`](https://github.com/lotabout/skim) & `bash`
 
 ```
 #!/usr/bin/env bash
-ZJ_SESSIONS=$(zellij list-sessions)
+ZJ_SESSIONS=$(zellij list-sessions --short --no-formatting)
 NO_SESSIONS=$(echo "${ZJ_SESSIONS}" | wc -l)
 
 if [ "${NO_SESSIONS}" -ge 2 ]; then


### PR DESCRIPTION
`zellij list-sessions` prints ANSI color escape codes by default.

It causes a bug in `List current sessions` script.

![Screenshot 2024-08-17 at 21 42 33](https://github.com/user-attachments/assets/a1985444-e476-4e89-910b-d9ed21946660)

Referred to https://github.com/zellij-org/zellij/blob/d76c4e5e49430414acd94b3270145ce0ca99d0ed/zellij-utils/assets/completions/comp.fish#L2
