### PR TITLE
Fix watch-serve.sh for docker

### DIFF
--- a/watch-serve.sh
+++ b/watch-serve.sh
@@ -36,7 +36,7 @@ elif $(_exists docker); then
     CRT="$(which docker)"
     echo "Using '$CRT' as container runtime"
 
-    $CRT build --tag "$CONTAINER_NAME" <Containerfile
+    $CRT build --tag "$CONTAINER_NAME" - <Containerfile
     $CRT run --rm -it --user "$(id -u):$(id -g)" -v "$PWD:$PWD" -w "$PWD" -p 1313:1313 $CONTAINER_NAME
 
 else


### PR DESCRIPTION
The error below is printed when I executed `watch-serve.sh` with docker.

```
❯ ./watch-serve.sh
Using '/usr/local/bin/docker' as container runtime
"docker build" requires exactly 1 argument.
See 'docker build --help'.

Usage:  docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile
```

`docker build` will accept Dockerfile from stdin if `-` is passed