### PR TITLE
FIX: Typo in scrollback_lines_to_serialize example

### DIFF
--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -267,7 +267,7 @@ Options:
   - `int`: serialize this much lines for each pane (max is the scrollback limit)
 
 ```javascript
-pane_viewport_serialization 100
+scrollback_lines_to_serialize 100
 ```
 
 ### disable_session_metadata


### PR DESCRIPTION
Fixing typo in options.