### PR TITLE
Add link for Hyper alt option enable in macOS

### DIFF
--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -22,6 +22,7 @@ This depends on which terminal emulator you're using. Here are some links that m
 1. [iTerm2](https://www.reddit.com/r/zellij/comments/13twru4/comment/kpmsjv2/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button)
 2. [Terminal.app](https://superuser.com/questions/1038947/using-the-option-key-properly-on-mac-terminal)
 3. [Alacritty](https://github.com/zellij-org/zellij/issues/2051#issuecomment-1461519892)
+4. [Kitty](https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.macos_option_as_alt)
 
 ## Copy / Paste isn't working, how can I fix this?
 Some terminals don't support the the OSC 52 signal, which is the method Zellij uses by default to copy text to the clipboard. To get around this, you can either switch to a supported terminal (eg. Alacritty or xterm) or configure Zellij to use an external utility when copy pasting (eg. xclip, wl-copy or pbcopy).

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -23,6 +23,7 @@ This depends on which terminal emulator you're using. Here are some links that m
 2. [Terminal.app](https://superuser.com/questions/1038947/using-the-option-key-properly-on-mac-terminal)
 3. [Alacritty](https://github.com/zellij-org/zellij/issues/2051#issuecomment-1461519892)
 4. [Kitty](https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.macos_option_as_alt)
+5. [Hyper](https://apple.stackexchange.com/a/445917)
 
 ## Copy / Paste isn't working, how can I fix this?
 Some terminals don't support the the OSC 52 signal, which is the method Zellij uses by default to copy text to the clipboard. To get around this, you can either switch to a supported terminal (eg. Alacritty or xterm) or configure Zellij to use an external utility when copy pasting (eg. xclip, wl-copy or pbcopy).

--- a/static/documentation/faq.html
+++ b/static/documentation/faq.html
@@ -190,6 +190,7 @@
 <li><a href="https://www.reddit.com/r/zellij/comments/13twru4/comment/kpmsjv2/?utm_source=share&amp;utm_medium=web3x&amp;utm_name=web3xcss&amp;utm_term=1&amp;utm_content=share_button">iTerm2</a></li>
 <li><a href="https://superuser.com/questions/1038947/using-the-option-key-properly-on-mac-terminal">Terminal.app</a></li>
 <li><a href="https://github.com/zellij-org/zellij/issues/2051#issuecomment-1461519892">Alacritty</a></li>
+<li><a href="https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.macos_option_as_alt">Kitty</a></li>
 </ol>
 <h2 id="copy--paste-isnt-working-how-can-i-fix-this"><a class="header" href="#copy--paste-isnt-working-how-can-i-fix-this">Copy / Paste isn't working, how can I fix this?</a></h2>
 <p>Some terminals don't support the the OSC 52 signal, which is the method Zellij uses by default to copy text to the clipboard. To get around this, you can either switch to a supported terminal (eg. Alacritty or xterm) or configure Zellij to use an external utility when copy pasting (eg. xclip, wl-copy or pbcopy).</p>

--- a/static/documentation/faq.html
+++ b/static/documentation/faq.html
@@ -191,6 +191,7 @@
 <li><a href="https://superuser.com/questions/1038947/using-the-option-key-properly-on-mac-terminal">Terminal.app</a></li>
 <li><a href="https://github.com/zellij-org/zellij/issues/2051#issuecomment-1461519892">Alacritty</a></li>
 <li><a href="https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.macos_option_as_alt">Kitty</a></li>
+<li><a href="https://apple.stackexchange.com/a/445917">Hyper</a></li>
 </ol>
 <h2 id="copy--paste-isnt-working-how-can-i-fix-this"><a class="header" href="#copy--paste-isnt-working-how-can-i-fix-this">Copy / Paste isn't working, how can I fix this?</a></h2>
 <p>Some terminals don't support the the OSC 52 signal, which is the method Zellij uses by default to copy text to the clipboard. To get around this, you can either switch to a supported terminal (eg. Alacritty or xterm) or configure Zellij to use an external utility when copy pasting (eg. xclip, wl-copy or pbcopy).</p>


### PR DESCRIPTION
Adds an explanation for enabling the Alt option in Hyper.
cherry-picked the commit from #204 for this update.






