### PR TITLE
Add Ghostty documentation for session-management tutorial/notes

### DIFF
--- a/content/tutorials/session-management.md
+++ b/content/tutorials/session-management.md
@@ -42,6 +42,14 @@ program = "zellij"
 args = ["-l", "welcome"]
 ```
 
+### In Ghostty
+Locate your [Ghostty configuration file](https://ghostty.org/docs/config#file-location) and add the following:
+```toml
+command = "zellij -l welcome"
+```
+This sets zellij with the `welcome` layout as the default shell.
+[See the Ghostty documentation for the difference between command and initial-command](https://ghostty.org/docs/config/reference#initial-command) for a more nuanced workflow.
+
 ### In gnome-terminal
 Follow [these instructions](https://help.gnome.org/users/gnome-terminal/stable/pref-custom-command.html.en) and pass the command `zellij -l welcome`.
 


### PR DESCRIPTION
This PR adds Ghostty configuration steps for the `Session Management with Zellij` tutorial. 

Thanks for zellij @imsnif , I can't conceive of a terminal workflow without it. :bow: