### PR TITLE
Clarification: default location of layouts by an example in mdbook/layouts.md

### DIFF
--- a/docs/src/layouts.md
+++ b/docs/src/layouts.md
@@ -48,7 +48,8 @@ For security reasons, remote layouts will have all their commands suspended behi
 
 ### Layout default directory
 
-By default Zellij will load the `default.kdl` layout, found in the `layouts` directory (a subdirectory of the `config` directory [config/layouts]).
+By default Zellij will load the `default.kdl` layout, found in the `layouts` directory (a subdirectory of the `config` directory).
+This will be probably under `~/.config/zellij/layouts` on a Linux system.
 
 If not found, Zellij will start with one pane and one tab.
 


### PR DESCRIPTION
The previous entry with [config/layouts] confused me and mislaid me into creating `~/.config/zellij/config/layouts`  instead of `~/.config/zellij/layouts`.

Replacing ` [config/layouts]` with  `~/.config/zellij/layouts` as an example for Linux is much clearer to me maybe to others too.