### PR TITLE
Fix typo: WhileWord -> WholeWord

### DIFF
--- a/docs/src/keybindings-possible-actions.md
+++ b/docs/src/keybindings-possible-actions.md
@@ -358,7 +358,7 @@ or:
 
  Toggle various search options on/off
 
-**Required arguments**: "CaseSensitivity" | "Wrap" | "WhileWord"
+**Required arguments**: "CaseSensitivity" | "Wrap" | "WholeWord"
 
 ```javascript
     bind "a" { SearchToggleOption "CaseSensitivity"; }


### PR DESCRIPTION
As per https://github.com/zellij-org/zellij/blob/main/zellij-utils/src/input/actions.rs#L76 this was a typo