### PR TITLE
Add playback speed controls to all video players

### DIFF
--- a/content/tutorials/colliding-keybindings.md
+++ b/content/tutorials/colliding-keybindings.md
@@ -3,7 +3,7 @@ title: "Dealing with Colliding Keyboard Shortcuts"
 date: 2024-11-11T14:45:48+01:00
 images: ["/img/configuration-screen-1.png"]
 description: "Solve keyboard shortcut conflicts in Zellij. Learn about the unlock-first preset to prevent key intercepts while maintaining workflow efficiency."
-linktitle: "How to quickly solve the issue of Zellij intercepting keys while still maintaining peak efficiency in one\'s workflow"
+linktitle: "How to quickly solve the issue of Zellij intercepting keys while still maintaining peak efficiency in one's workflow"
 ---
 {{<video-left-aligned "/video/colliding-keybindings-screencast.mp4">}}
 

--- a/layouts/shortcodes/video-left-aligned.html
+++ b/layouts/shortcodes/video-left-aligned.html
@@ -2,9 +2,14 @@
   <div id="player-wrapper" class="{{ .Get 1 }}"></div>
 </div>
 
-<script 
-  type="text/javascript" 
-  src="https://cdn.jsdelivr.net/npm/@clappr/player@latest/dist/clappr.min.js"
+<script
+  type="text/javascript"
+  src="https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js"
+>
+</script>
+<script
+  type="text/javascript"
+  src="https://cdn.jsdelivr.net/npm/clappr-playback-rate-plugin@latest/dist/clappr-playback-rate-plugin.min.js"
 >
 </script>
 
@@ -17,8 +22,18 @@
     // height: 360,
     height: 540,
     // width: 640
-    width: 960
+    width: 960,
+    plugins: [PlaybackRatePlugin],
+    playbackRateConfig: {
+      defaultValue: 1,
+      options: [
+        {value: 0.5, label: '0.5x'},
+        {value: 1, label: '1x'},
+        {value: 1.5, label: '1.5x'},
+        {value: 2, label: '2x'},
+      ]
+    }
   });
 
-  player.attachTo(playerElement);  
+  player.attachTo(playerElement);
 </script>

--- a/layouts/shortcodes/video-left-aligned.html
+++ b/layouts/shortcodes/video-left-aligned.html
@@ -1,39 +1,14 @@
 <div class="container" style="display: flex; justify-content: left; align-items: left;">
-  <div id="player-wrapper" class="{{ .Get 1 }}"></div>
+  <video class="{{ .Get 1 }}" style="max-width: 960px; width: 100%;">
+    <source src={{ .Get 0 }} type="video/mp4">
+  </video>
 </div>
 
-<script
-  type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js"
->
-</script>
-<script
-  type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/clappr-playback-rate-plugin@latest/dist/clappr-playback-rate-plugin.min.js"
->
-</script>
-
+<link rel="stylesheet" href="https://cdn.plyr.io/3.7.8/plyr.css">
+<script src="https://cdn.plyr.io/3.7.8/plyr.polyfilled.js"></script>
 <script>
-  var playerElement = document.getElementById("player-wrapper");
-
-  var player = new Clappr.Player({
-    source: {{ .Get 0 }},
-    mute: false,
-    // height: 360,
-    height: 540,
-    // width: 640
-    width: 960,
-    plugins: [PlaybackRatePlugin],
-    playbackRateConfig: {
-      defaultValue: 1,
-      options: [
-        {value: 0.5, label: '0.5x'},
-        {value: 1, label: '1x'},
-        {value: 1.5, label: '1.5x'},
-        {value: 2, label: '2x'},
-      ]
-    }
+  document.querySelectorAll('video:not(.plyr--setup)').forEach(function(el) {
+    var p = new Plyr(el, { speed: { selected: 1, options: [0.5, 1, 1.5, 2] } });
+    el.classList.add('plyr--setup');
   });
-
-  player.attachTo(playerElement);
 </script>

--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -1,37 +1,14 @@
 <div class="container" style="display: flex; justify-content: center; align-items: center;">
-  <div id="player-wrapper" class="{{ .Get 1 }}"></div>
+  <video class="{{ .Get 1 }}" style="max-width: 640px; width: 100%;">
+    <source src={{ .Get 0 }} type="video/mp4">
+  </video>
 </div>
 
-<script
-  type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js"
->
-</script>
-<script
-  type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/clappr-playback-rate-plugin@latest/dist/clappr-playback-rate-plugin.min.js"
->
-</script>
-
+<link rel="stylesheet" href="https://cdn.plyr.io/3.7.8/plyr.css">
+<script src="https://cdn.plyr.io/3.7.8/plyr.polyfilled.js"></script>
 <script>
-  var playerElement = document.getElementById("player-wrapper");
-
-  var player = new Clappr.Player({
-    source: {{ .Get 0 }},
-    mute: false,
-    height: 360,
-    width: 640,
-    plugins: [PlaybackRatePlugin],
-    playbackRateConfig: {
-      defaultValue: 1,
-      options: [
-        {value: 0.5, label: '0.5x'},
-        {value: 1, label: '1x'},
-        {value: 1.5, label: '1.5x'},
-        {value: 2, label: '2x'},
-      ]
-    }
+  document.querySelectorAll('video:not(.plyr--setup)').forEach(function(el) {
+    var p = new Plyr(el, { speed: { selected: 1, options: [0.5, 1, 1.5, 2] } });
+    el.classList.add('plyr--setup');
   });
-
-  player.attachTo(playerElement);
 </script>

--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -2,9 +2,14 @@
   <div id="player-wrapper" class="{{ .Get 1 }}"></div>
 </div>
 
-<script 
-  type="text/javascript" 
-  src="https://cdn.jsdelivr.net/npm/@clappr/player@latest/dist/clappr.min.js"
+<script
+  type="text/javascript"
+  src="https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js"
+>
+</script>
+<script
+  type="text/javascript"
+  src="https://cdn.jsdelivr.net/npm/clappr-playback-rate-plugin@latest/dist/clappr-playback-rate-plugin.min.js"
 >
 </script>
 
@@ -15,8 +20,18 @@
     source: {{ .Get 0 }},
     mute: false,
     height: 360,
-    width: 640
+    width: 640,
+    plugins: [PlaybackRatePlugin],
+    playbackRateConfig: {
+      defaultValue: 1,
+      options: [
+        {value: 0.5, label: '0.5x'},
+        {value: 1, label: '1x'},
+        {value: 1.5, label: '1.5x'},
+        {value: 2, label: '2x'},
+      ]
+    }
   });
 
-  player.attachTo(playerElement);  
+  player.attachTo(playerElement);
 </script>


### PR DESCRIPTION
## Summary
- Replace Clappr video player with [Plyr](https://plyr.io/) — a lighter player with built-in speed controls
- Adds playback speed selector (0.5x, 1x, 1.5x, 2x) via Plyr's settings menu on all 14 pages with embedded videos
- Removes two CDN dependencies (clappr + clappr-playback-rate-plugin), replaced by one (plyr)
- Fix an invalid escaped quote in `colliding-keybindings.md` frontmatter that broke Hugo builds

## Test plan
- [x] Visit any tutorial page (e.g. `/tutorials/basic-functionality/`) and verify the Plyr video player renders
- [x] Click the gear icon in the control bar and verify "Speed" shows 0.5x, 1x, 1.5x, 2x options
- [x] Select a different speed and verify playback rate changes
- [x] Check both shortcode variants: centered (`/news/config-command-layouts/`) and left-aligned (`/tutorials/basic-functionality/`)
- [x] Verify play, pause, seek, volume, PiP, and fullscreen still work