### PR TITLE
fix: lowercase 'stacked' in NewPane docs

### DIFF
--- a/docs/src/keybindings-possible-actions.md
+++ b/docs/src/keybindings-possible-actions.md
@@ -363,7 +363,7 @@ There is also `MessagePluginId` which sends a message to a specific running plug
 
  Open a new pane (in the specified direction)
 
-**Possible arguments**: `Down` | `Right` | `Stacked`
+**Possible arguments**: `Down` | `Right` | `stacked`
 
 **Behaviour without arguments**: Opens a pane in the largest available space or if floating panes are visible, in the next floating pane position.
 
@@ -372,7 +372,7 @@ There is also `MessagePluginId` which sends a message to a specific running plug
 ```
 or open a stacked pane:
 ```javascript
-    bind "a" { NewPane "Stacked"; }
+    bind "a" { NewPane "stacked"; }
 ```
 
 **Note**: For more advanced pane creation options (floating coordinates, borderless, close-on-exit, cwd, etc.), use the [`Run`](#run) keybinding action instead.

--- a/static/documentation/keybindings-possible-actions.html
+++ b/static/documentation/keybindings-possible-actions.html
@@ -384,12 +384,12 @@
 </code></pre>
 <h2 id="newpane"><a class="header" href="#newpane"><code>NewPane</code></a></h2>
 <p>Open a new pane (in the specified direction)</p>
-<p><strong>Possible arguments</strong>: <code>Down</code> | <code>Right</code> | <code>Stacked</code></p>
+<p><strong>Possible arguments</strong>: <code>Down</code> | <code>Right</code> | <code>stacked</code></p>
 <p><strong>Behaviour without arguments</strong>: Opens a pane in the largest available space or if floating panes are visible, in the next floating pane position.</p>
 <pre><code class="language-javascript">    bind "a" { NewPane "Right"; }
 </code></pre>
 <p>or open a stacked pane:</p>
-<pre><code class="language-javascript">    bind "a" { NewPane "Stacked"; }
+<pre><code class="language-javascript">    bind "a" { NewPane "stacked"; }
 </code></pre>
 <p><strong>Note</strong>: For more advanced pane creation options (floating coordinates, borderless, close-on-exit, cwd, etc.), use the <a href="#run"><code>Run</code></a> keybinding action instead.</p>
 <h2 id="newtab"><a class="header" href="#newtab"><code>NewTab</code></a></h2>

--- a/static/documentation/print.html
+++ b/static/documentation/print.html
@@ -1247,12 +1247,12 @@ bind "Left" // bind the left arrow key
 </code></pre>
 <h2 id="newpane"><a class="header" href="#newpane"><code>NewPane</code></a></h2>
 <p>Open a new pane (in the specified direction)</p>
-<p><strong>Possible arguments</strong>: <code>Down</code> | <code>Right</code> | <code>Stacked</code></p>
+<p><strong>Possible arguments</strong>: <code>Down</code> | <code>Right</code> | <code>stacked</code></p>
 <p><strong>Behaviour without arguments</strong>: Opens a pane in the largest available space or if floating panes are visible, in the next floating pane position.</p>
 <pre><code class="language-javascript">    bind "a" { NewPane "Right"; }
 </code></pre>
 <p>or open a stacked pane:</p>
-<pre><code class="language-javascript">    bind "a" { NewPane "Stacked"; }
+<pre><code class="language-javascript">    bind "a" { NewPane "stacked"; }
 </code></pre>
 <p><strong>Note</strong>: For more advanced pane creation options (floating coordinates, borderless, close-on-exit, cwd, etc.), use the <a href="keybindings-possible-actions.html#run"><code>Run</code></a> keybinding action instead.</p>
 <h2 id="newtab"><a class="header" href="#newtab"><code>NewTab</code></a></h2>


### PR DESCRIPTION
closes https://github.com/zellij-org/zellij/issues/4519

I ran into this issue where `bind "F2" { NewPane "Stacked" }` did not work, lowercase `"stacked"` however worked perfectly fine. The presets in the [zellij repo](https://github.com/zellij-org/zellij/blob/main/default-plugins/configuration/src/presets.rs#L34) also use the lowercase `"stacked"` so this must be a typo in the docs?
 
 NOTE: I was using Zellij version `0.43.1` when I encountered this