### PR TITLE
Add Windows config path to configuration page

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -18,10 +18,11 @@ Zellij will search for the `config` directory as follows:
 
 - `--config-dir` flag
 - `ZELLIJ_CONFIG_DIR` env variable
-- `$HOME/.config/zellij`
+- `$HOME/.config/zellij` or `%APPDATA%/Zellij/config`
 - default location
     - Linux: `/home/alice/.config/zellij`
     - Mac: `/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij`
+    - Windows: `C:/Users/Alice/AppData/Roaming/Zellij/config`
 
 - system location (`/etc/zellij`)
 


### PR DESCRIPTION
Because I'm using `nushell` on windows and some apps do follow a unix-like config path pattern, it took me a little bit of exploring to discover why zellij was not respecting my config at `C:/Users/username/.config/zellij/config.kdl` - It was instead reading `C:/Users/username/AppData/Roaming/Zellij/config/config.kdl`

This change specifies this on the configuration page of the User Guide to help future windows users.