### PR TITLE
docs: copy_command in Zellij User Guide FAQ not using kdl format

### DIFF
--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -44,9 +44,9 @@ Some terminals don't support the the OSC 52 signal, which is the method Zellij u
 To do the latter, add one of the following to your [Zellij Config](./configuration.md):
 
 ```
-copy_command: "xclip -selection clipboard" # x11
-copy_command: "wl-copy"                    # wayland
-copy_command: "pbcopy"                     # osx
+copy_command "xclip -selection clipboard" // x11
+copy_command "wl-copy"                    // wayland
+copy_command "pbcopy"                     // osx
 ```
 
 Note that the only method that works when connecting to a remote Zellij session (eg. through SSH) is OSC 52. If you require this functionality, please consider using a terminal that supports it.


### PR DESCRIPTION
In https://github.com/zellij-org/zellij/pull/1759 the format of the config was changed to kdl, but the FAQ wasn't updated.

Specifically, it has a section about "Copy / Paste isn't working, how can I fix this?" which says you can add a line such as `copy_command: "xclip -selection clipboard" # x11` to your config. I confirmed this doesn't work. If you change it to `copy_command "xclip -selection clipboard" // x11` then it works fine. Needed `:` removed as well as comment updated to be `//` instead of `#`.